### PR TITLE
chore: update dotnet core to v6; add GraphQL packages via Nuget

### DIFF
--- a/twofifteen-api.csproj
+++ b/twofifteen-api.csproj
@@ -6,7 +6,9 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="6.0.6" />
+    <TargetFramework Include="Microsoft.AspNetCore.App" Version="6.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.6" />
+    <PackageReference Include="HotChocolate.AspNetCore.Playground" Version="10.5.5" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="12.11.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- This PR updates the ancient, original API project to use .NET Core 6.0 (was v2.1)
- Additionally the csproj file also adds GraphQL via Hot Chocolate